### PR TITLE
refactor: 提取快速触发协调器

### DIFF
--- a/Copied-mac/.gitignore
+++ b/Copied-mac/.gitignore
@@ -3,6 +3,7 @@
 docs/
 Tests/*
 !Tests/QuickTriggerStateMachineTests.swift
+!Tests/QuickTriggerCoordinatorTests.swift
 !Tests/AppUpdateModelsTests.swift
 !Tests/AppUpdateServiceTests.swift
 !Tests/InteractionWiringTests.swift

--- a/Copied-mac/CLAUDE.md
+++ b/Copied-mac/CLAUDE.md
@@ -33,11 +33,12 @@ BlacklistSourceAppAction.swift  右键"屏蔽此来源" Action
 ClipboardAction.swift       Action 协议 + 内置 Action + ActionResolver
 KeyboardShortcutSettings.swift  快速触发修饰键、双击/单击模式、侧键配置
 QuickTriggerModifierKeyPolicy.swift  按实际 keyCode 维护左右修饰键状态
+QuickTriggerCoordinator.swift  键盘/侧键快速触发监听、生命周期与上下文守卫
 MouseButtonRecordingStateMachine.swift  侧键录制状态与取消/绑定决策
 AppUpdateService.swift      GitHub Releases 检查、缓存、节流与提醒状态
 ToastPanel.swift            nonactivating NSPanel + first-mouse hosting + 原生展开文本
 ToastCommand.swift          弹窗内部命令 + 同步防重入分发
-ToastWindowController.swift ToastPanel + Action + 展开文本分层 + 键盘/侧键快速触发
+ToastWindowController.swift ToastPanel + Action + 展开文本分层 + 快速触发 Context/Command 路由
 ToastViewModel.swift        @Observable 模型（含 sourceBundleID）
 RelativeDateDescription.swift 日期/时间详情格式化（日历日语义 + 本地化时间）
 ToastView.swift             SwiftUI 卡片 + glassEffect（macOS 26+）/ ultraThinMaterial（降级）+ 展开查看全文（if/else 双态）+ contextMenu
@@ -55,11 +56,11 @@ UserDefaults 键：`searchEngine`, `launchAtLogin`, `isPaused`, `copyGestureEnab
 
 **数据流**：`ClipboardMonitor` → `DetectionRegistry.detectAll()` → `SourceAppDetector.detect()` → `AppFilterSettings.shouldShowPopup()` 过滤门 → `ClipboardContent` → 分支：轻提醒模式 → `LightReminderController.show()`，标准模式 → `ToastWindowController.show()` → `ToastViewModel` → `ToastView`
 
-**插件系统**：声明式（JSON + 正则，不执行代码）。插件目录 `~/Library/Application Support/Copied/Plugins/`，通过设置 → 智能识别手动安装。规则支持 `multiline`（默认 false）、`menuOnly`（强制进右键菜单）字段。无默认插件，不自动安装。性能熔断：>100KB 文本仅运行内置语言检测器（跳过插件与实体检测器）、>50ms 单检测器限流 30s、连续 3 次限流自动禁用。
+**插件系统**：声明式 JSON + 正则，不执行代码。目录为 `~/Library/Application Support/Copied/Plugins/`，只从设置手动安装；规则支持 `multiline`、`menuOnly`，无默认插件。性能边界统一由 `DetectionRegistry` 管理。
 
 ### 轻提醒模式（LightReminderController）
 
-菜单栏右键 / 设置页 Toggle 切换。开启后复制只显示鼠标右上方的 24pt `checkmark.app.fill` 浮标，1s 自消。浮标用忽略鼠标的 borderless floating `NSWindow` + `NSHostingView`，每次 `show()` 重建且不跟踪鼠标。
+开启后只显示鼠标右上方的 24pt `checkmark.app.fill` 浮标，1s 自消。使用忽略鼠标的 borderless floating `NSWindow` + `NSHostingView`，每次 `show()` 重建。
 
 **绘制动画陷阱**：Symbol 默认已是完整绘制态，`drawOn(isActive:)` 会反向擦除。必须用 `drawOff(isActive: !show)`：初始 `show=false` 隐藏，`onAppear` 后切为 true 反向播放；palette 使用白勾蓝底。macOS 26 以下改用 `.opacity` 淡入。
 
@@ -67,13 +68,13 @@ UserDefaults 键：`searchEngine`, `launchAtLogin`, `isPaused`, `copyGestureEnab
 
 ### 窗口（glassEffect / 降级）
 
-**macOS 26+**：`.glassEffect(in: .rect(cornerRadius: cardCornerRadius))` — 液态玻璃。**pre-macOS 26**：ZStack 内 `RoundedRectangle.fill(.ultraThinMaterial)` + 0.08s 延迟淡入，避免 WindowServer 材质合成首帧灰色闪烁。统一常量 `cardCornerRadius: CGFloat = 32`。
+macOS 26+ 用 `.glassEffect(in: .rect(cornerRadius: cardCornerRadius))`；旧系统用 `.ultraThinMaterial` + 0.08s 延迟淡入，避免首帧灰闪。圆角统一为 32pt。
 
 标准弹窗必须使用 `ToastPanel`：`NSPanel + .borderless + .nonactivatingPanel`，`canBecomeKey=true`、`canBecomeMain=false`、`becomesKeyOnlyIfNeeded=true`、`isFloatingPanel=true`、`hidesOnDeactivate=false`。普通 SwiftUI 控件位于 `needsPanelToBecomeKey=false` 的 first-mouse hosting 中，点击不得激活 Copied 或让 Panel 成为 key；只有原生展开文本交互可按需成为 key。
 
-非 key 浮动窗口的边缘高光被 WindowServer 抑制 → `.stroke(.primary.opacity(0.15))` 补偿（`.primary` 自适应亮/暗模式）。每次 `show()` 重建窗口（不复用）— 全屏 Space 长时间使用后复用窗口可能导致 `orderFront` 无效、toast 不出现。窗口配置见 `ToastWindowController.createWindow()`，动画参数见 `ToastView.swift`。
+非 key 窗口用 `.stroke(.primary.opacity(0.15))` 补偿边缘高光。每次 `show()` 必须重建窗口；复用窗口在全屏 Space 长时间运行后可能无法 `orderFront`。
 
-退场动画陷阱：`layerUsesCoreImageFilters = true` 必须设（AppKit 默认不启用）、`CIFilter.name` 必须匹配动画 keyPath、清理覆盖三条路径（动画回调 / `cancelDismiss()` / 非动画 dismiss）。
+退场动画必须启用 `layerUsesCoreImageFilters`，让 `CIFilter.name` 匹配 keyPath，并覆盖动画回调、`cancelDismiss()`、非动画 dismiss 三条清理路径。
 
 ### 鼠标交互
 
@@ -96,23 +97,21 @@ SwiftUI `Button` 是鼠标 `ToastCommand` 的唯一来源；禁止恢复窗口�
 
 ### 本地化
 
-`Localizable.xcstrings` 以 `zh-Hans` 为源语言，完整支持 `en` 和 `zh-Hant`。App 完全跟随 macOS 系统语言或单 App 语言设置，不增加语言 UserDefaults 或 App 内切换器。SwiftUI 字面量由 `LocalizedStringKey` 查询；先生成 `String` 的内置文案使用 `String(localized:)`；剪贴板内容、插件作者文案、文件名和 App 名称保持原文。
+`Localizable.xcstrings` 以 `zh-Hans` 为源语言，支持 `en` / `zh-Hant`。App 只跟随系统或单 App 语言，不增加语言 UserDefaults/切换器；生成后的内置文案用 `String(localized:)`，剪贴板内容、插件文案、文件名和 App 名保持原文。
 
-`AppLanguage.isContentKindAvailable(_:)` 是语言相关检测策略的唯一入口：英文界面在检测管道和设置页同时隐藏 `englishPhrase`，且不改写 `disabledContentKinds`；中文界面保留英文单词翻译，所有语言都保留拼音及其他检测。中文年月日会先生成 ISO 候选再交给 `NSDataDetector`，禁止让输入识别结果依赖界面 Locale。
+`AppLanguage.isContentKindAvailable(_:)` 是语言检测策略唯一入口：英文界面同时隐藏并跳过 `englishPhrase`，且不改写 `disabledContentKinds`；其他检测保持可用。输入识别不得依赖界面 Locale，中文年月日先转 ISO 候选再交给 `NSDataDetector`。
 
-日期检测的 `metadata["subtype"]` 必须按原始文本区分 `date` / `dateTime` / `time`，不能从解析后的 `DateComponents` 推断（`NSDataDetector` 会补齐缺失字段并给纯日期分配时刻）。`RelativeDateDescription` 对纯日期和日期时间按 `Calendar.startOfDay` 的日历组件生成“今天/明天/后天”等命名结果，日期时间再附本地化短时间；仅时间保留真实时差。
+日期 `metadata["subtype"]` 必须按原文区分 `date` / `dateTime` / `time`，禁止从会补齐字段的 `DateComponents` 推断。`RelativeDateDescription` 对日期按 `Calendar.startOfDay` 生成日历日描述；日期时间附短时间，仅时间按真实时差。
 
 ### Action 系统
 
-**内联更新模式**（`performsInlineUpdate = true`）：执行后弹窗保持显示，展示**结果覆盖层**（`ResultOverlay { displayText, copyText }`）。右侧按钮变为"复制"（`CopyTextAction`）。覆盖层 `\n` 拆分 VStack，每行 `.lineLimit(1)`，`ScrollView` + `.frame(maxHeight: 200)` 防止超长内容撑爆屏幕。
+**内联更新**（`performsInlineUpdate = true`）：Action 后保留弹窗并显示 `ResultOverlay { displayText, copyText }`，主按钮改为 `CopyTextAction`；结果逐行 `.lineLimit(1)`，滚动区上限 200pt。
 
-**词典查询**（`LookupAction`）：`DCSCopyTextDefinition` 查询 macOS 内置牛津中英词典，零配置。返回格式：行1 = `{word} 英 {pron}`，行2 = 中文释义（≤5 字 CJK，≤8 条）。检测器仅匹配单个 ASCII 单词，词典预查在 `ActionResolver.makeAction()` 中进行：有释义→显示"翻译"按钮，无释义→兜底搜索。**预查不能放检测器**（检测器在主线程有 50ms 超时熔断，词典首次加载会触发）。
+**词典查询**：`LookupAction` 使用 `DCSCopyTextDefinition`。预查只能在 `ActionResolver.makeAction()`，有释义显示翻译、无释义回退搜索；禁止放进受 50ms 熔断约束的检测器。
 
-**优先级**：首个非颜色检测 → 右侧按钮（最多 1 个）。其余 → 右键菜单。无检测 → 默认搜索。纯语言类型（如 swift）不产生按钮。各 Action 触发条件和行为见 `ClipboardAction.swift` 及各 `*Action.swift`。
+**优先级**：首个非颜色检测占右侧唯一按钮，其余进右键菜单；无检测默认搜索，纯语言类型不产生按钮。规则以 `ClipboardAction.swift` 和各 `*Action.swift` 为准。
 
-**按钮背景**：`actionButtonBackground` 双路径——macOS 26+ `.glassEffect(.regular.interactive())` 原生液态玻璃，pre-26 `.fill(.quaternary)` 语义色。不再用 `.white.opacity()` 硬编码（浅色模式不可见）。
-
-**按钮 hover 图标**：用 `ZStack` 叠加两个 SF Symbol + `opacity` 切换，不能用 `Image(systemName: condition ? "A" : "B")`——SF Symbol 宽度不同会导致按钮尺寸变化 → HStack 重排 → 左侧文本截断位置跳动。
+**视觉约束**：按钮背景在 macOS 26+ 用 `.glassEffect(.regular.interactive())`，旧系统用 `.fill(.quaternary)`；禁止硬编码白色。hover 图标必须以 `ZStack` + `opacity` 切换，条件替换不同宽度的 SF Symbol 会触发 HStack 重排和文本跳动。
 
 ### 开机自启
 
@@ -120,11 +119,11 @@ rebuild 后签名变化会使 macOS 清掉 `SMAppService` 登录项注册记录�
 
 ### 展开查看全文（ToastView expand/collapse）
 
-`ExpandedTextView` 固定宽 360、总高最多 300pt，只在主 SwiftUI host 中预留几何空间。controller 在卡片背景上方安装原生 `NSTextView + NSScrollView`，再叠加不接收鼠标的玻璃视觉 host 和独立 SwiftUI 按钮 host；正文因此可在底栏后方滚动，底部圆角由 scroll layer 裁剪。文档高度必须取 `NSLayoutManager.usedRect` 后再额外加 52pt，不能只依赖 `boundingRect` 或在排版前设置 frame，否则 `NSTextView` 会收缩并遮住最后一两行。`updateWindowSize` 上限 340pt。所有内容类型均可展开，`expandedText` 优先级为结果覆盖层 > 原文 > 文件名+路径。
+`ExpandedTextView` 固定宽 360、总高最多 300pt；主 host 只预留几何空间，controller 分层安装原生 `NSTextView/NSScrollView`、无命中玻璃 host 和独立按钮 host。文档高度必须取 `NSLayoutManager.usedRect` 再加 52pt，`updateWindowSize` 上限 340pt；`expandedText` 优先级为结果覆盖层 > 原文 > 文件名+路径。
 
-展开态交互：进入展开态时移除键盘/侧键快速触发监听，收起后重新安装。只有原生文本需要 Panel 成为 key，并直接使用 responder chain 支持拖选、⌘C 和右键菜单；普通底栏按钮仍保持 Panel non-key。按钮栏中间透明 SwiftUI Button 负责关闭，不使用坐标命中。Escape 不提供操作。TextEdit 操作写 UUID 临时文件后用 `NSWorkspace` 打开，且动作入口必须防重入。
+展开期间暂停全部快速触发。只有原生正文按需让 Panel 成为 key，并通过 responder chain 支持拖选、⌘C 和右键菜单；底栏按钮保持 non-key，中间透明 SwiftUI Button 负责关闭，禁止坐标命中，Escape 无操作。TextEdit 使用 UUID 临时文件并防重入。
 
-过渡必须使用全窗口 CIGaussianBlur + alpha 两段式切换，并由 `isExpandingOrCollapsing` 防重入；窗口 resize 不做动画。
+展开/收起必须用全窗口 CIGaussianBlur + alpha 两段式切换，以 `isExpandingOrCollapsing` 防重入；resize 不做动画。
 
 ### 点击处理
 
@@ -132,25 +131,25 @@ rebuild 后签名变化会使 macOS 清掉 `SMAppService` 登录项注册记录�
 
 ### 快速触发（修饰键）
 
-Toast 有主操作按钮（或结果覆盖层）时，默认在第一次 Control 松开后的 350ms 内再次按下并松开 Control 触发。设置 → 通用 → 快速触发可改为 Command/Option/Shift、关闭键盘触发，或启用单击（高级）模式；原生鼠标侧键可作为并行触发。按钮 hover 时动态显示对应图标。
+`QuickTriggerCoordinator` 独占键盘/侧键监听、状态机、350ms timeout、20ms HID poll、设置快照和视觉去重。`ToastWindowController` 只提供以 `dismissGeneration` 为 ID 的有效性/可执行 Context，并把执行回调路由到 `ToastCommand.performPrimary`；禁止把 token、状态机或定时任务放回 controller。
 
-普通鼠标输入取消快速触发时，只有视觉状态实际变化才写 `quickTriggerVisualState`，禁止在 idle → idle 时触发 SwiftUI 重绘。展开态没有主操作按钮，因此暂停全部快速触发监听；收起或新 toast 出现时恢复，不改变折叠态的键盘/侧键行为。
+`start` / `suspend` / `resume` / `stop` 必须幂等：折叠可执行态 start，展开前 suspend，收起完成 resume，关闭或换代 stop。context/monitor epoch 必须使旧 modifier release、mouseUp、timeout 和 poll 永久失效；视觉回调禁止 idle → idle。
 
-**输入边界**：从第一次按下到第二次松开之间，出现普通键、其他修饰键、鼠标点击或滚轮即取消。键盘路径不需要辅助功能权限；侧键录制/触发与左右键复制共享 `GlobalMouseEventCoordinator` 的 CGEventTap，需要辅助功能权限。
+默认在第一次 Control 松开后的 350ms 内再次按下并松开触发；支持其他修饰键、高级单击、禁用键盘和 button number ≥3 的原生侧键。从第一次按下到第二次松开之间出现普通键、其他修饰键、鼠标点击或滚轮即取消。
 
-1. **实际 keyCode 策略** — `QuickTriggerModifierKeyPolicy` 按左右修饰键 keyCode 转换状态；不要用聚合 flags 推断按键，因为 macOS 可能携带残留 Function/NumericPad flags。
-2. **本地事件 + HID 计数器** — 捕获组合键、鼠标与滚轮输入；事件计数变化即中止。
-3. **`dismissGeneration` 守卫** — 防止旧弹窗的延迟释放触发新 toast Action。
+- `QuickTriggerModifierKeyPolicy` 必须按左右真实 keyCode 维护状态，禁止用可能夹带 Function/NumericPad 的聚合 flags 推断。
+- 本地只监听 `.keyDown` / `.flagsChanged`；普通鼠标输入走共享 `GlobalMouseEventCoordinator` + HID 计数，禁止另建 Event Tap 或左键 NSEvent monitor。
+- 键盘路径无需辅助功能权限；侧键录制/触发与左右键复制共享 CGEventTap，需要权限。
 
-**侧键限制**：只绑定 button number ≥3 的原生 `otherMouseDown`。Mac Mouse Fix 等重映射工具可能在 Copied 前拦截或改写事件；此时需关闭对应映射或保留原生侧键。
+**重映射工具限制**：Mac Mouse Fix 等工具可能在 CGEvent/AppKit/HID 计数之前吞掉原生侧键或“修饰键 + 滚轮”。关闭对应映射或保留原生事件即可；不要增加重复监听或 raw IOHID 绕过路径。
 
 ### 版本与更新
 
-`VERSION` 是构建版本单一来源，`build.sh` 同步写入 `CFBundleShortVersionString`。菜单栏显示实际版本并可打开关于页；有更新时显示绿色圆点和“有新版本”。关于页可手动检查，自动提醒最多每天成功检查一次、失败一小时后重试；只读取 GitHub 最新稳定 Release，更新按钮打开 GitHub，不做应用内下载安装。标准 Toast 右上角用 `arrow.up.circle.fill` 提醒，点击进入关于页；轻提醒模式不叠加更新提醒。
+`VERSION` 是构建版本单一来源，`build.sh` 写入 Bundle 版本。只检查 GitHub 最新稳定 Release；成功检查每天最多一次、失败一小时后重试，更新入口打开 GitHub，不做应用内安装。标准 Toast 可显示更新入口，轻提醒不叠加提醒。
 
 ### 菜单栏
 
-`MenuBarExtra` + `Copied.svg` 模板图像。`build.sh` 将 `fill="white"` 替换为 `fill="black"` 做模板遮罩。设置与版本放在同一区域，版本项位于退出上方，点击打开关于页。暂停/恢复直接读 `UserDefaults`。`Info.plist` 设 `LSUIElement = YES`。
+`MenuBarExtra` 使用 `Copied.svg` 模板图；`build.sh` 将白色填充转为黑色模板遮罩。暂停状态直接读 `UserDefaults`，版本项打开关于页；`LSUIElement = YES`。
 
 ### 左右键快捷复制（CopyGestureManager）
 
@@ -175,20 +174,6 @@ Toast 有主操作按钮（或结果覆盖层）时，默认在第一次 Control
 4. **修复后清理日志代码**。
 
 **为什么不用 Console.app**：CGEventTap/NSEvent 每秒数百条，混在全系统日志中无法定位。文件日志只含关心的状态，一行一事。
-
-模板：
-```swift
-private static let logURL = FileManager.default.temporaryDirectory
-    .appendingPathComponent("copied_debug.log")
-private func dlog(_ s: String) {
-    let line = "\(Date().timeIntervalSince1970) \(s)\n"
-    if let d = line.data(using: .utf8) {
-        if let fh = try? FileHandle(forWritingTo: logURL) { fh.seekToEndOfFile(); fh.write(d); try? fh.close() }
-        else { try? d.write(to: logURL, options: .atomic) }
-    }
-}
-// 启动时：try? Data().write(to: logURL, options: .atomic)
-```
 
 ## GitHub 推送规则（硬性）
 

--- a/Copied-mac/QuickTriggerCoordinator.swift
+++ b/Copied-mac/QuickTriggerCoordinator.swift
@@ -1,0 +1,604 @@
+import AppKit
+import CoreGraphics
+import Foundation
+
+final class QuickTriggerCancellation {
+    private var cancellation: (() -> Void)?
+    private(set) var isCancelled = false
+
+    init(_ cancellation: @escaping () -> Void) {
+        self.cancellation = cancellation
+    }
+
+    func cancel() {
+        guard let cancellation else { return }
+        self.cancellation = nil
+        isCancelled = true
+        cancellation()
+    }
+
+    deinit {
+        cancel()
+    }
+}
+
+struct QuickTriggerModifierEvent: Equatable {
+    let keyCode: UInt16
+    let modifierFlags: NSEvent.ModifierFlags
+    let timestamp: TimeInterval
+}
+
+struct QuickTriggerMouseEvent: Equatable {
+    enum Kind: Equatable {
+        case leftDown
+        case leftUp
+        case rightDown
+        case rightUp
+        case otherDown
+        case otherUp
+        case scrollWheel
+    }
+
+    let kind: Kind
+    let button: Int
+}
+
+struct QuickTriggerCoordinatorEnvironment {
+    var readSettings: () -> QuickTriggerSettings
+    var currentModifierFlags: () -> NSEvent.ModifierFlags
+    var captureEventCounters: () -> QuickTriggerEventCounters
+    var systemUptime: () -> TimeInterval
+    var dispatchAsync: (@escaping () -> Void) -> Void
+    var schedule: (_ delay: TimeInterval, _ action: @escaping () -> Void) -> QuickTriggerCancellation
+    var addGlobalModifierMonitor: (
+        _ handler: @escaping (QuickTriggerModifierEvent) -> Void
+    ) -> QuickTriggerCancellation?
+    var addLocalModifierMonitor: (
+        _ handler: @escaping (QuickTriggerModifierEvent) -> Void
+    ) -> QuickTriggerCancellation?
+    var addLocalKeyDownMonitor: (
+        _ handler: @escaping () -> Void
+    ) -> QuickTriggerCancellation?
+    var addMouseListener: (
+        _ handler: @escaping (QuickTriggerMouseEvent) -> Bool
+    ) -> QuickTriggerCancellation?
+
+    static var live: QuickTriggerCoordinatorEnvironment {
+        QuickTriggerCoordinatorEnvironment(
+            readSettings: { QuickTriggerSettings.current() },
+            currentModifierFlags: { NSEvent.modifierFlags },
+            captureEventCounters: {
+                func count(_ type: CGEventType) -> UInt32 {
+                    CGEventSource.counterForEventType(.hidSystemState, eventType: type)
+                }
+                return QuickTriggerEventCounters(
+                    keyDown: count(.keyDown),
+                    leftMouseDown: count(.leftMouseDown),
+                    leftMouseUp: count(.leftMouseUp),
+                    rightMouseDown: count(.rightMouseDown),
+                    rightMouseUp: count(.rightMouseUp),
+                    otherMouseDown: count(.otherMouseDown),
+                    otherMouseUp: count(.otherMouseUp),
+                    scrollWheel: count(.scrollWheel)
+                )
+            },
+            systemUptime: { ProcessInfo.processInfo.systemUptime },
+            dispatchAsync: { action in DispatchQueue.main.async(execute: action) },
+            schedule: { delay, action in
+                let work = DispatchWorkItem(block: action)
+                DispatchQueue.main.asyncAfter(deadline: .now() + delay, execute: work)
+                return QuickTriggerCancellation { work.cancel() }
+            },
+            addGlobalModifierMonitor: { handler in
+                guard let token = NSEvent.addGlobalMonitorForEvents(matching: .flagsChanged, handler: {
+                    event in
+                    MainActor.assumeIsolated {
+                        handler(
+                            QuickTriggerModifierEvent(
+                                keyCode: event.keyCode,
+                                modifierFlags: event.modifierFlags,
+                                timestamp: event.timestamp
+                            )
+                        )
+                    }
+                }) else { return nil }
+                return QuickTriggerCancellation { NSEvent.removeMonitor(token) }
+            },
+            addLocalModifierMonitor: { handler in
+                guard let token = NSEvent.addLocalMonitorForEvents(matching: .flagsChanged, handler: {
+                    event in
+                    MainActor.assumeIsolated {
+                        handler(
+                            QuickTriggerModifierEvent(
+                                keyCode: event.keyCode,
+                                modifierFlags: event.modifierFlags,
+                                timestamp: event.timestamp
+                            )
+                        )
+                    }
+                    return event
+                }) else { return nil }
+                return QuickTriggerCancellation { NSEvent.removeMonitor(token) }
+            },
+            addLocalKeyDownMonitor: { handler in
+                guard let token = NSEvent.addLocalMonitorForEvents(matching: .keyDown, handler: {
+                    event in
+                    MainActor.assumeIsolated { handler() }
+                    return event
+                }) else { return nil }
+                return QuickTriggerCancellation { NSEvent.removeMonitor(token) }
+            },
+            addMouseListener: { handler in
+                let token = GlobalMouseEventCoordinator.shared.addListener(
+                    promptForAccessibility: false
+                ) { type, event in
+                    guard let kind = QuickTriggerMouseEvent.Kind(cgEventType: type) else {
+                        return false
+                    }
+                    let mouseEvent = QuickTriggerMouseEvent(
+                        kind: kind,
+                        button: Int(event.getIntegerValueField(.mouseEventButtonNumber))
+                    )
+                    return MainActor.assumeIsolated { handler(mouseEvent) }
+                }
+                guard let token else { return nil }
+                return QuickTriggerCancellation {
+                    GlobalMouseEventCoordinator.shared.removeListener(token)
+                }
+            }
+        )
+    }
+}
+
+private extension QuickTriggerMouseEvent.Kind {
+    init?(cgEventType: CGEventType) {
+        switch cgEventType {
+        case .leftMouseDown: self = .leftDown
+        case .leftMouseUp: self = .leftUp
+        case .rightMouseDown: self = .rightDown
+        case .rightMouseUp: self = .rightUp
+        case .otherMouseDown: self = .otherDown
+        case .otherMouseUp: self = .otherUp
+        case .scrollWheel: self = .scrollWheel
+        default: return nil
+        }
+    }
+}
+
+final class QuickTriggerCoordinator {
+    struct Context {
+        let id: Int
+        let isValid: () -> Bool
+        let canPerform: () -> Bool
+    }
+
+    var onPerformPrimary: (() -> Void)?
+    var onVisualStateChanged: ((QuickTriggerVisualState) -> Void)?
+
+    private enum Lifecycle {
+        case stopped
+        case active
+        case suspended
+    }
+
+    private let environment: QuickTriggerCoordinatorEnvironment
+    private var lifecycle: Lifecycle = .stopped
+    private var context: Context?
+    private var settings: QuickTriggerSettings?
+    private var contextEpoch = 0
+    private var monitoringEpoch = 0
+    private var monitoringInstalled = false
+
+    private var globalModifierMonitor: QuickTriggerCancellation?
+    private var localModifierMonitor: QuickTriggerCancellation?
+    private var localKeyDownMonitor: QuickTriggerCancellation?
+    private var mouseListener: QuickTriggerCancellation?
+    private var timeout: QuickTriggerCancellation?
+    private var hidPoll: QuickTriggerCancellation?
+
+    private var keyboardState = KeyboardQuickTriggerStateMachine(mode: .doubleTap)
+    private var modifierPolicy = QuickTriggerModifierKeyPolicy(targetModifier: .control)
+    private var mouseState = MouseQuickTriggerStateMachine()
+    private var publishedVisualState = QuickTriggerVisualState.idle
+
+    init(environment: QuickTriggerCoordinatorEnvironment = .live) {
+        self.environment = environment
+    }
+
+    func start(context newContext: Context) {
+        let newSettings = environment.readSettings()
+        let sameContext = context?.id == newContext.id
+        let settingsChanged = settings != newSettings
+
+        switch lifecycle {
+        case .stopped:
+            context = newContext
+            settings = newSettings
+            lifecycle = .active
+            resetSequence(for: newSettings)
+            reconcileMonitoring()
+
+        case .suspended:
+            context = newContext
+            if !sameContext || settingsChanged {
+                settings = newSettings
+                resetSequence(for: newSettings)
+            }
+
+        case .active:
+            context = newContext
+            if !sameContext || settingsChanged {
+                let shouldReinstall = settingsChanged
+                if shouldReinstall { removeMonitoring() }
+                settings = newSettings
+                resetSequence(for: newSettings)
+            } else if !monitoringInstalled {
+                resetSequence(for: newSettings)
+            }
+            reconcileMonitoring()
+        }
+    }
+
+    func suspend() {
+        guard lifecycle == .active else { return }
+        lifecycle = .suspended
+        removeMonitoring()
+    }
+
+    func resume(context newContext: Context) {
+        if lifecycle == .active {
+            start(context: newContext)
+            return
+        }
+        guard lifecycle == .suspended else { return }
+        let newSettings = environment.readSettings()
+        context = newContext
+        settings = newSettings
+        lifecycle = .active
+        resetSequence(for: newSettings)
+        reconcileMonitoring()
+    }
+
+    func stop() {
+        guard lifecycle != .stopped || context != nil || monitoringInstalled else { return }
+        lifecycle = .stopped
+        removeMonitoring()
+        context = nil
+        settings = nil
+    }
+
+    private func reconcileMonitoring() {
+        guard lifecycle == .active,
+              let context,
+              context.isValid(),
+              context.canPerform() else {
+            removeMonitoring()
+            return
+        }
+        if !monitoringInstalled { installMonitoring() }
+    }
+
+    private func installMonitoring() {
+        guard lifecycle == .active, !monitoringInstalled, let settings else { return }
+        monitoringInstalled = true
+        monitoringEpoch += 1
+        let installedEpoch = monitoringEpoch
+
+        if settings.keyboardModifier != .disabled {
+            globalModifierMonitor = environment.addGlobalModifierMonitor { [weak self] event in
+                self?.handleModifierEvent(event, monitoringEpoch: installedEpoch)
+            }
+            localModifierMonitor = environment.addLocalModifierMonitor { [weak self] event in
+                self?.handleModifierEvent(event, monitoringEpoch: installedEpoch)
+            }
+        }
+        localKeyDownMonitor = environment.addLocalKeyDownMonitor { [weak self] in
+            self?.handleLocalKeyDown(monitoringEpoch: installedEpoch)
+        }
+        mouseListener = environment.addMouseListener { [weak self] event in
+            self?.handleMouseEvent(event, monitoringEpoch: installedEpoch) ?? false
+        }
+    }
+
+    private func removeMonitoring() {
+        monitoringEpoch += 1
+        globalModifierMonitor?.cancel()
+        localModifierMonitor?.cancel()
+        localKeyDownMonitor?.cancel()
+        mouseListener?.cancel()
+        globalModifierMonitor = nil
+        localModifierMonitor = nil
+        localKeyDownMonitor = nil
+        mouseListener = nil
+        monitoringInstalled = false
+        invalidateSequence()
+    }
+
+    private func resetSequence(for settings: QuickTriggerSettings) {
+        contextEpoch += 1
+        cancelScheduledTasks()
+        keyboardState = KeyboardQuickTriggerStateMachine(mode: settings.keyboardMode)
+        modifierPolicy = QuickTriggerModifierKeyPolicy(targetModifier: settings.keyboardModifier)
+        mouseState.reset()
+        let targetIsDown = settings.keyboardModifier != .disabled
+            && environment.currentModifierFlags().contains(settings.keyboardModifier.nseventFlags)
+        modifierPolicy.appeared(preExisting: targetIsDown)
+        keyboardState.appeared(preExisting: targetIsDown)
+        publishVisualState(.idle)
+    }
+
+    private func invalidateSequence() {
+        contextEpoch += 1
+        cancelScheduledTasks()
+        keyboardState.contextChanged()
+        modifierPolicy.reset()
+        mouseState.reset()
+        publishVisualState(.idle)
+    }
+
+    private func cancelScheduledTasks() {
+        timeout?.cancel()
+        hidPoll?.cancel()
+        timeout = nil
+        hidPoll = nil
+    }
+
+    private func handleModifierEvent(
+        _ event: QuickTriggerModifierEvent,
+        monitoringEpoch installedEpoch: Int
+    ) {
+        guard callbackIsCurrent(monitoringEpoch: installedEpoch) else { return }
+        guard settingsAreCurrent() else { return }
+        guard contextIsUsable() else {
+            invalidateSequence()
+            return
+        }
+        guard let settings, settings.keyboardModifier != .disabled else {
+            cancelKeyboard()
+            return
+        }
+
+        let counters = environment.captureEventCounters()
+        let decision = modifierPolicy.handleFlagsChanged(
+            keyCode: event.keyCode,
+            eventFlags: event.modifierFlags,
+            sequenceActive: keyboardState.visualState != .idle
+        )
+
+        let isDown: Bool
+        switch decision {
+        case .ignore:
+            return
+        case .cancelOtherModifier:
+            cancelKeyboard()
+            cancelMouse()
+            return
+        case .cancelTargetSideConflict:
+            cancelKeyboard()
+            cancelMouse()
+            return
+        case .targetDown:
+            isDown = true
+        case .targetUp:
+            isDown = false
+        }
+        cancelMouse()
+
+        if isDown {
+            let shouldPerform = keyboardState.targetChanged(
+                isDown: true,
+                at: event.timestamp,
+                counters: counters,
+                context: contextEpoch
+            )
+            updateKeyboardVisualState()
+            if shouldPerform { performPrimary() }
+        } else {
+            let capturedContextEpoch = contextEpoch
+            let capturedContextID = context?.id
+            let timestamp = event.timestamp
+            environment.dispatchAsync { [weak self] in
+                guard let self,
+                      self.asyncCallbackIsCurrent(
+                        contextEpoch: capturedContextEpoch,
+                        contextID: capturedContextID
+                      ),
+                      self.settingsAreCurrent() else { return }
+                let releaseCounters = self.environment.captureEventCounters()
+                let shouldPerform = self.keyboardState.targetChanged(
+                    isDown: false,
+                    at: timestamp,
+                    counters: releaseCounters,
+                    context: capturedContextEpoch
+                )
+                self.updateKeyboardVisualState()
+                if shouldPerform { self.performPrimary() }
+            }
+        }
+    }
+
+    private func handleLocalKeyDown(monitoringEpoch installedEpoch: Int) {
+        guard callbackIsCurrent(monitoringEpoch: installedEpoch) else { return }
+        guard settingsAreCurrent() else { return }
+        cancelKeyboard()
+        cancelMouse()
+    }
+
+    private func handleMouseEvent(
+        _ event: QuickTriggerMouseEvent,
+        monitoringEpoch installedEpoch: Int
+    ) -> Bool {
+        guard callbackIsCurrent(monitoringEpoch: installedEpoch) else { return false }
+        guard settingsAreCurrent() else { return false }
+        cancelKeyboard()
+        guard let configuredButton = settings?.mouseButton else {
+            cancelMouse()
+            return false
+        }
+
+        switch event.kind {
+        case .otherDown where event.button == configuredButton:
+            let capturedContextEpoch = contextEpoch
+            let capturedContextID = context?.id
+            let consume = mouseState.mouseDown(
+                button: event.button,
+                configuredButton: configuredButton,
+                context: capturedContextEpoch,
+                canPerform: contextIsUsable()
+            )
+            if consume {
+                environment.dispatchAsync { [weak self] in
+                    guard let self,
+                          self.asyncCallbackIsCurrent(
+                            contextEpoch: capturedContextEpoch,
+                            contextID: capturedContextID
+                          ) else { return }
+                    self.publishVisualState(.pressed)
+                }
+            }
+            return consume
+
+        case .otherUp where event.button == configuredButton:
+            let capturedContextEpoch = contextEpoch
+            let capturedContextID = context?.id
+            let result = mouseState.mouseUp(
+                button: event.button,
+                context: capturedContextEpoch
+            )
+            if result.consume {
+                environment.dispatchAsync { [weak self] in
+                    guard let self,
+                          self.asyncCallbackIsCurrent(
+                            contextEpoch: capturedContextEpoch,
+                            contextID: capturedContextID
+                          ) else { return }
+                    self.publishVisualState(.idle)
+                    if result.trigger { self.performPrimary() }
+                }
+            }
+            return result.consume
+
+        default:
+            cancelMouse()
+            return false
+        }
+    }
+
+    private func updateKeyboardVisualState() {
+        timeout?.cancel()
+        timeout = nil
+        publishVisualState(keyboardState.visualState)
+        scheduleHIDValidation()
+
+        guard keyboardState.visualState == .waitingForSecondTap else { return }
+        let capturedContextEpoch = contextEpoch
+        let capturedContextID = context?.id
+        timeout = environment.schedule(0.351) { [weak self] in
+            guard let self,
+                  self.asyncCallbackIsCurrent(
+                    contextEpoch: capturedContextEpoch,
+                    contextID: capturedContextID
+                  ),
+                  self.settingsAreCurrent() else { return }
+            self.timeout = nil
+            self.keyboardState.tick(at: self.environment.systemUptime())
+            self.publishVisualState(self.keyboardState.visualState)
+            if self.keyboardState.visualState == .idle {
+                self.hidPoll?.cancel()
+                self.hidPoll = nil
+            }
+        }
+    }
+
+    private func scheduleHIDValidation() {
+        hidPoll?.cancel()
+        hidPoll = nil
+        guard keyboardState.visualState != .idle else { return }
+        let capturedContextEpoch = contextEpoch
+        let capturedContextID = context?.id
+        hidPoll = environment.schedule(0.020) { [weak self] in
+            guard let self,
+                  self.asyncCallbackIsCurrent(
+                    contextEpoch: capturedContextEpoch,
+                    contextID: capturedContextID
+                  ),
+                  self.settingsAreCurrent() else { return }
+            self.hidPoll = nil
+            let isValid = self.keyboardState.validate(
+                counters: self.environment.captureEventCounters(),
+                context: capturedContextEpoch
+            )
+            self.publishVisualState(self.keyboardState.visualState)
+            if isValid, self.keyboardState.visualState != .idle {
+                self.scheduleHIDValidation()
+            }
+        }
+    }
+
+    private func cancelKeyboard() {
+        timeout?.cancel()
+        hidPoll?.cancel()
+        timeout = nil
+        hidPoll = nil
+        keyboardState.cancel()
+        publishVisualState(.idle)
+    }
+
+    private func cancelMouse() {
+        mouseState.cancelPendingTrigger()
+    }
+
+    private func settingsAreCurrent() -> Bool {
+        let current = environment.readSettings()
+        guard current == settings else {
+            settings = current
+            invalidateSequence()
+            let capturedContextID = context?.id
+            let capturedContextEpoch = contextEpoch
+            environment.dispatchAsync { [weak self] in
+                guard let self,
+                      self.lifecycle == .active,
+                      self.context?.id == capturedContextID,
+                      self.contextEpoch == capturedContextEpoch,
+                      self.settings == current else { return }
+                self.removeMonitoring()
+                self.resetSequence(for: current)
+                self.reconcileMonitoring()
+            }
+            return false
+        }
+        return true
+    }
+
+    private func callbackIsCurrent(monitoringEpoch installedEpoch: Int) -> Bool {
+        lifecycle == .active
+            && monitoringInstalled
+            && installedEpoch == monitoringEpoch
+    }
+
+    private func asyncCallbackIsCurrent(contextEpoch: Int, contextID: Int?) -> Bool {
+        lifecycle == .active
+            && contextEpoch == self.contextEpoch
+            && contextID == context?.id
+            && contextIsUsable()
+    }
+
+    private func contextIsUsable() -> Bool {
+        guard lifecycle == .active, let context else { return false }
+        return context.isValid() && context.canPerform()
+    }
+
+    private func performPrimary() {
+        guard contextIsUsable() else {
+            invalidateSequence()
+            return
+        }
+        onPerformPrimary?()
+    }
+
+    private func publishVisualState(_ state: QuickTriggerVisualState) {
+        guard state != publishedVisualState else { return }
+        publishedVisualState = state
+        onVisualStateChanged?(state)
+    }
+}

--- a/Copied-mac/README.md
+++ b/Copied-mac/README.md
@@ -39,7 +39,7 @@ pip3 install 'dmgbuild>=1.6.5'   # 首次需安装
 
 复制任意内容 → 卡片弹出。悬停保持，点击预览行展开全文，点击右侧按钮执行操作，点击图标、来源信息或其他空白区域关闭。默认在第一次 Control 松开后的 350ms 内再次按下并松开 Control，即可触发主操作；设置中也可选择单击模式、其他修饰键或原生鼠标侧键。
 
-侧键录制需要辅助功能权限。Mac Mouse Fix 等鼠标重映射工具可能在事件到达 Copied 前将侧键拦截或改写；此时需在该工具中保留原生侧键事件，或关闭对应映射。
+侧键录制需要辅助功能权限。Mac Mouse Fix 等鼠标重映射工具可能在事件到达 Copied 前拦截或改写原生侧键、“修饰键 + 滚轮”等输入；此时只需在该工具中关闭对应映射或保留原生事件，无需退出整个工具。
 
 右键菜单提供搜索、另存为、类型专属操作，以及一键将当前 App 加入黑名单。设置中可开启左右键手势（按住左键+右键=⌘C）、管理检测类型、管理黑名单、安装插件。
 
@@ -60,12 +60,13 @@ AppFilterSettings.swift     — 应用黑名单过滤 + 持久化
 ClipboardAction.swift       — Action 协议 + 内置 Action + ActionResolver
 KeyboardShortcutSettings.swift — 快速触发修饰键、双击/单击模式和侧键配置
 QuickTriggerModifierKeyPolicy.swift — 按实际键码处理修饰键状态与冲突
+QuickTriggerCoordinator.swift — 键盘/侧键快速触发监听、生命周期与上下文保护
 AppUpdateService.swift      — GitHub Releases 版本检查、缓存与提醒节流
 FilePreviewGenerator.swift  — QLThumbnailGenerator 异步文件缩略图
 SourceAppDetector.swift     — NSWorkspace 前台 App 检测（含 bundleIdentifier）
 ToastPanel.swift            — nonactivating NSPanel + first-mouse hosting / 原生展开文本
 ToastCommand.swift          — 弹窗内部命令与单次分发
-ToastWindowController.swift — ToastPanel、展开文本分层与快速触发管理（标准模式）
+ToastWindowController.swift — ToastPanel、展开文本分层与快速触发命令路由（标准模式）
 LightReminderController.swift — 轻提醒模式浮标（NSWindow + drawOff 反向动画）
 ToastView.swift             — SwiftUI 卡片 + 展开查看全文 + 色块 + 右键菜单
 ToastViewModel.swift        — @Observable 模型（含展开状态管理）

--- a/Copied-mac/Tests/QuickTriggerCoordinatorTests.swift
+++ b/Copied-mac/Tests/QuickTriggerCoordinatorTests.swift
@@ -1,0 +1,494 @@
+import AppKit
+import Foundation
+
+private func expect(_ condition: @autoclosure () -> Bool, _ message: String) {
+    guard condition() else {
+        fputs("FAIL: \(message)\n", stderr)
+        exit(1)
+    }
+}
+
+private final class ScheduledProbe {
+    let delay: TimeInterval
+    let action: () -> Void
+    var isCancelled = false
+    var hasFired = false
+
+    init(delay: TimeInterval, action: @escaping () -> Void) {
+        self.delay = delay
+        self.action = action
+    }
+
+    func fire(evenIfCancelled: Bool = false) {
+        guard !hasFired, evenIfCancelled || !isCancelled else { return }
+        hasFired = true
+        action()
+    }
+}
+
+private final class FakeQuickTriggerEnvironment {
+    var settings = QuickTriggerSettings(
+        keyboardModifier: .control,
+        keyboardMode: .doubleTap,
+        mouseButton: 3
+    )
+    var modifierFlags: NSEvent.ModifierFlags = []
+    var counters = QuickTriggerEventCounters.zero
+    var uptime: TimeInterval = 0
+
+    var globalInstallCount = 0
+    var localModifierInstallCount = 0
+    var localKeyInstallCount = 0
+    var mouseInstallCount = 0
+    var globalRemoveCount = 0
+    var localModifierRemoveCount = 0
+    var localKeyRemoveCount = 0
+    var mouseRemoveCount = 0
+
+    var globalHandlers: [(QuickTriggerModifierEvent) -> Void] = []
+    var localModifierHandlers: [(QuickTriggerModifierEvent) -> Void] = []
+    var localKeyHandlers: [() -> Void] = []
+    var mouseHandlers: [(QuickTriggerMouseEvent) -> Bool] = []
+    var activeGlobalHandler: ((QuickTriggerModifierEvent) -> Void)?
+    var activeLocalModifierHandler: ((QuickTriggerModifierEvent) -> Void)?
+    var activeLocalKeyHandler: (() -> Void)?
+    var activeMouseHandler: ((QuickTriggerMouseEvent) -> Bool)?
+    private var activeGlobalID = 0
+    private var activeLocalModifierID = 0
+    private var activeLocalKeyID = 0
+    private var activeMouseID = 0
+
+    var asyncActions: [() -> Void] = []
+    var scheduled: [ScheduledProbe] = []
+
+    func makeEnvironment() -> QuickTriggerCoordinatorEnvironment {
+        QuickTriggerCoordinatorEnvironment(
+            readSettings: { [unowned self] in settings },
+            currentModifierFlags: { [unowned self] in modifierFlags },
+            captureEventCounters: { [unowned self] in counters },
+            systemUptime: { [unowned self] in uptime },
+            dispatchAsync: { [unowned self] action in asyncActions.append(action) },
+            schedule: { [unowned self] delay, action in
+                let probe = ScheduledProbe(delay: delay, action: action)
+                scheduled.append(probe)
+                return QuickTriggerCancellation { probe.isCancelled = true }
+            },
+            addGlobalModifierMonitor: { [unowned self] handler in
+                globalInstallCount += 1
+                activeGlobalID = globalInstallCount
+                let id = activeGlobalID
+                globalHandlers.append(handler)
+                activeGlobalHandler = handler
+                return QuickTriggerCancellation { [unowned self] in
+                    globalRemoveCount += 1
+                    if activeGlobalID == id { activeGlobalHandler = nil }
+                }
+            },
+            addLocalModifierMonitor: { [unowned self] handler in
+                localModifierInstallCount += 1
+                activeLocalModifierID = localModifierInstallCount
+                let id = activeLocalModifierID
+                localModifierHandlers.append(handler)
+                activeLocalModifierHandler = handler
+                return QuickTriggerCancellation { [unowned self] in
+                    localModifierRemoveCount += 1
+                    if activeLocalModifierID == id { activeLocalModifierHandler = nil }
+                }
+            },
+            addLocalKeyDownMonitor: { [unowned self] handler in
+                localKeyInstallCount += 1
+                activeLocalKeyID = localKeyInstallCount
+                let id = activeLocalKeyID
+                localKeyHandlers.append(handler)
+                activeLocalKeyHandler = handler
+                return QuickTriggerCancellation { [unowned self] in
+                    localKeyRemoveCount += 1
+                    if activeLocalKeyID == id { activeLocalKeyHandler = nil }
+                }
+            },
+            addMouseListener: { [unowned self] handler in
+                mouseInstallCount += 1
+                activeMouseID = mouseInstallCount
+                let id = activeMouseID
+                mouseHandlers.append(handler)
+                activeMouseHandler = handler
+                return QuickTriggerCancellation { [unowned self] in
+                    mouseRemoveCount += 1
+                    if activeMouseID == id { activeMouseHandler = nil }
+                }
+            }
+        )
+    }
+
+    func fireModifier(
+        keyCode: UInt16,
+        flags: NSEvent.ModifierFlags,
+        timestamp: TimeInterval
+    ) {
+        activeGlobalHandler?(
+            QuickTriggerModifierEvent(
+                keyCode: keyCode,
+                modifierFlags: flags,
+                timestamp: timestamp
+            )
+        )
+    }
+
+    @discardableResult
+    func fireMouse(_ kind: QuickTriggerMouseEvent.Kind, button: Int = 0) -> Bool {
+        activeMouseHandler?(QuickTriggerMouseEvent(kind: kind, button: button)) ?? false
+    }
+
+    func flushAsync() {
+        while !asyncActions.isEmpty {
+            let action = asyncActions.removeFirst()
+            action()
+        }
+    }
+
+    func firstActiveScheduled(delay: TimeInterval) -> ScheduledProbe? {
+        scheduled.first {
+            !$0.isCancelled && !$0.hasFired && abs($0.delay - delay) < 0.000_001
+        }
+    }
+}
+
+private final class ContextProbe {
+    var validIDs: Set<Int> = []
+    var canPerform = true
+
+    func context(_ id: Int) -> QuickTriggerCoordinator.Context {
+        QuickTriggerCoordinator.Context(
+            id: id,
+            isValid: { [unowned self] in validIDs.contains(id) },
+            canPerform: { [unowned self] in canPerform }
+        )
+    }
+}
+
+@main
+struct QuickTriggerCoordinatorTests {
+    static func main() {
+        lifecycleOperationsAreIdempotent()
+        deinitReleasesOwnedResources()
+        doubleTapTriggersOnSecondReleaseOnly()
+        timeoutAndHIDCancellationAreBounded()
+        singleTapSupportsEveryModifier()
+        ordinaryInputDoesNotPublishIdleAgain()
+        staleContextAndCallbacksCannotPerform()
+        settingsChangesReplaceTheOldSequence()
+        sideButtonPairsOnceAndRejectsStaleUp()
+        disabledInputsDoNotTrigger()
+        ineligibleContextDoesNotInstallUntilEligible()
+        print("QuickTriggerCoordinatorTests: PASS")
+    }
+
+    private static func makeCoordinator(
+        fake: FakeQuickTriggerEnvironment,
+        contextProbe: ContextProbe,
+        id: Int = 1
+    ) -> (QuickTriggerCoordinator, () -> Int, () -> [QuickTriggerVisualState]) {
+        contextProbe.validIDs.insert(id)
+        let coordinator = QuickTriggerCoordinator(environment: fake.makeEnvironment())
+        var performCount = 0
+        var visuals: [QuickTriggerVisualState] = []
+        coordinator.onPerformPrimary = { performCount += 1 }
+        coordinator.onVisualStateChanged = { visuals.append($0) }
+        coordinator.start(context: contextProbe.context(id))
+        return (
+            coordinator,
+            { _ = coordinator; return performCount },
+            { _ = coordinator; return visuals }
+        )
+    }
+
+    private static func lifecycleOperationsAreIdempotent() {
+        let fake = FakeQuickTriggerEnvironment()
+        let context = ContextProbe()
+        let (coordinator, performCount, visuals) = makeCoordinator(
+            fake: fake,
+            contextProbe: context
+        )
+
+        expect(fake.globalInstallCount == 1, "start installs one global modifier monitor")
+        expect(fake.localModifierInstallCount == 1, "start installs one local modifier monitor")
+        expect(fake.localKeyInstallCount == 1, "start installs one keyDown monitor")
+        expect(fake.mouseInstallCount == 1, "start installs one shared mouse listener")
+
+        coordinator.start(context: context.context(1))
+        expect(fake.globalInstallCount == 1, "repeated start does not reinstall")
+
+        fake.fireModifier(keyCode: 59, flags: .control, timestamp: 0)
+        let stalePoll = fake.firstActiveScheduled(delay: 0.020)
+        expect(stalePoll != nil, "pressed state schedules HID validation")
+
+        coordinator.suspend()
+        coordinator.suspend()
+        expect(fake.globalRemoveCount == 1, "repeated suspend removes global monitor once")
+        expect(fake.localModifierRemoveCount == 1, "suspend removes local modifier monitor")
+        expect(fake.localKeyRemoveCount == 1, "suspend removes keyDown monitor")
+        expect(fake.mouseRemoveCount == 1, "suspend removes mouse listener")
+        expect(stalePoll?.isCancelled == true, "suspend cancels pending HID poll")
+        let visualCountAfterSuspend = visuals().count
+        stalePoll?.fire(evenIfCancelled: true)
+        expect(visuals().count == visualCountAfterSuspend, "suspended stale poll cannot publish")
+        expect(performCount() == 0, "suspended stale poll cannot perform")
+
+        coordinator.resume(context: context.context(1))
+        coordinator.resume(context: context.context(1))
+        expect(fake.globalInstallCount == 2, "resume reinstalls exactly once")
+        expect(fake.mouseInstallCount == 2, "resume reinstalls mouse listener exactly once")
+
+        coordinator.stop()
+        coordinator.stop()
+        expect(fake.globalRemoveCount == 2, "repeated stop removes global monitor once")
+        expect(fake.mouseRemoveCount == 2, "repeated stop removes mouse listener once")
+    }
+
+    private static func deinitReleasesOwnedResources() {
+        let fake = FakeQuickTriggerEnvironment()
+        let context = ContextProbe()
+        context.validIDs.insert(1)
+        var coordinator: QuickTriggerCoordinator? = QuickTriggerCoordinator(
+            environment: fake.makeEnvironment()
+        )
+        coordinator?.start(context: context.context(1))
+        expect(fake.globalInstallCount == 1, "owned monitor is installed before deinit")
+        coordinator = nil
+        expect(fake.globalRemoveCount == 1, "deinit releases the global modifier monitor")
+        expect(fake.localModifierRemoveCount == 1, "deinit releases the local modifier monitor")
+        expect(fake.localKeyRemoveCount == 1, "deinit releases the keyDown monitor")
+        expect(fake.mouseRemoveCount == 1, "deinit releases the shared mouse listener")
+    }
+
+    private static func doubleTapTriggersOnSecondReleaseOnly() {
+        let fake = FakeQuickTriggerEnvironment()
+        let context = ContextProbe()
+        let (_, performCount, visuals) = makeCoordinator(fake: fake, contextProbe: context)
+
+        fake.fireModifier(keyCode: 59, flags: .control, timestamp: 0.0)
+        fake.fireModifier(keyCode: 59, flags: [], timestamp: 0.1)
+        fake.flushAsync()
+        expect(performCount() == 0, "first release does not perform in double-tap mode")
+        expect(
+            fake.firstActiveScheduled(delay: 0.351) != nil,
+            "double tap uses 351ms expiry for a 350ms window; scheduled=\(fake.scheduled.map { ($0.delay, $0.isCancelled, $0.hasFired) })"
+        )
+
+        fake.fireModifier(keyCode: 59, flags: .control, timestamp: 0.2)
+        expect(performCount() == 0, "second press does not perform before release")
+        fake.fireModifier(keyCode: 59, flags: [], timestamp: 0.3)
+        expect(performCount() == 0, "release remains deferred until the main queue callback")
+        fake.flushAsync()
+
+        expect(performCount() == 1, "second release performs exactly once")
+        expect(
+            visuals() == [.pressed, .waitingForSecondTap, .pressed, .idle],
+            "double tap publishes only value changes"
+        )
+    }
+
+    private static func timeoutAndHIDCancellationAreBounded() {
+        do {
+            let fake = FakeQuickTriggerEnvironment()
+            let context = ContextProbe()
+            let (_, performCount, visuals) = makeCoordinator(fake: fake, contextProbe: context)
+            fake.fireModifier(keyCode: 59, flags: .control, timestamp: 0.0)
+            fake.fireModifier(keyCode: 59, flags: [], timestamp: 0.1)
+            fake.flushAsync()
+            fake.uptime = 0.452
+            fake.firstActiveScheduled(delay: 0.351)?.fire()
+            expect(performCount() == 0, "timeout does not perform")
+            expect(visuals().last == .idle, "timeout resets waiting visual once")
+        }
+
+        do {
+            let fake = FakeQuickTriggerEnvironment()
+            let context = ContextProbe()
+            let (_, performCount, visuals) = makeCoordinator(fake: fake, contextProbe: context)
+            fake.fireModifier(keyCode: 59, flags: .control, timestamp: 0.0)
+            fake.fireModifier(keyCode: 59, flags: [], timestamp: 0.1)
+            fake.flushAsync()
+            fake.counters.scrollWheel = 1
+            fake.firstActiveScheduled(delay: 0.020)?.fire()
+            expect(performCount() == 0, "HID counter change cancels without performing")
+            expect(visuals().last == .idle, "HID counter change resets visual state")
+        }
+    }
+
+    private static func singleTapSupportsEveryModifier() {
+        let cases: [(KeyboardQuickTriggerModifier, UInt16, NSEvent.ModifierFlags)] = [
+            (.control, 59, .control),
+            (.command, 55, .command),
+            (.option, 58, .option),
+            (.shift, 56, .shift),
+        ]
+        for (modifier, keyCode, flags) in cases {
+            let fake = FakeQuickTriggerEnvironment()
+            fake.settings.keyboardModifier = modifier
+            fake.settings.keyboardMode = .singleTap
+            let context = ContextProbe()
+            let (_, performCount, _) = makeCoordinator(fake: fake, contextProbe: context)
+            fake.fireModifier(keyCode: keyCode, flags: flags, timestamp: 0.0)
+            fake.fireModifier(keyCode: keyCode, flags: [], timestamp: 0.1)
+            fake.flushAsync()
+            expect(performCount() == 1, "single tap performs once for \(modifier)")
+        }
+    }
+
+    private static func ordinaryInputDoesNotPublishIdleAgain() {
+        let fake = FakeQuickTriggerEnvironment()
+        let context = ContextProbe()
+        let (_, performCount, visuals) = makeCoordinator(fake: fake, contextProbe: context)
+        expect(!fake.fireMouse(.leftDown), "ordinary mouse down is not consumed")
+        expect(!fake.fireMouse(.leftUp), "ordinary mouse up is not consumed")
+        fake.activeLocalKeyHandler?()
+        expect(visuals().isEmpty, "idle ordinary input publishes no visual callback")
+
+        fake.fireModifier(keyCode: 59, flags: .control, timestamp: 0.0)
+        fake.fireModifier(keyCode: 55, flags: [.control, .command], timestamp: 0.1)
+        expect(performCount() == 0, "other real modifier cancels active sequence")
+        expect(visuals() == [.pressed, .idle], "pressed to idle publishes exactly once")
+    }
+
+    private static func staleContextAndCallbacksCannotPerform() {
+        let fake = FakeQuickTriggerEnvironment()
+        let context = ContextProbe()
+        let (coordinator, performCount, visuals) = makeCoordinator(fake: fake, contextProbe: context)
+
+        let stoppedModifierHandler = fake.globalHandlers[0]
+        fake.fireModifier(keyCode: 59, flags: .control, timestamp: 0.0)
+        fake.fireModifier(keyCode: 59, flags: [], timestamp: 0.1)
+        let staleTimeout = fake.firstActiveScheduled(delay: 0.351)
+
+        context.validIDs.insert(2)
+        coordinator.start(context: context.context(2))
+        let visualCountAfterReplacement = visuals().count
+        fake.flushAsync()
+        staleTimeout?.fire(evenIfCancelled: true)
+        expect(performCount() == 0, "old release and timeout cannot operate new context")
+        expect(visuals().count == visualCountAfterReplacement, "old callbacks cannot publish into new context")
+
+        coordinator.stop()
+        stoppedModifierHandler(
+            QuickTriggerModifierEvent(keyCode: 59, modifierFlags: .control, timestamp: 0.2)
+        )
+        stoppedModifierHandler(
+            QuickTriggerModifierEvent(keyCode: 59, modifierFlags: [], timestamp: 0.3)
+        )
+        fake.flushAsync()
+        expect(performCount() == 0, "stopped monitor callback is permanently stale")
+    }
+
+    private static func settingsChangesReplaceTheOldSequence() {
+        let fake = FakeQuickTriggerEnvironment()
+        let context = ContextProbe()
+        let (_, performCount, visuals) = makeCoordinator(fake: fake, contextProbe: context)
+        fake.fireModifier(keyCode: 59, flags: .control, timestamp: 0.0)
+        fake.settings.keyboardModifier = .command
+        fake.settings.keyboardMode = .singleTap
+        fake.fireModifier(keyCode: 59, flags: [], timestamp: 0.1)
+        expect(fake.globalRemoveCount == 0, "settings callback defers monitor replacement")
+        fake.flushAsync()
+
+        expect(fake.globalInstallCount == 2, "settings change replaces modifier monitors once")
+        expect(fake.globalRemoveCount == 1, "settings change removes old modifier monitor")
+        expect(performCount() == 0, "old settings sequence cannot perform")
+        expect(visuals().last == .idle, "settings change resets active visual state")
+
+        fake.fireModifier(keyCode: 55, flags: .command, timestamp: 0.2)
+        fake.fireModifier(keyCode: 55, flags: [], timestamp: 0.3)
+        fake.flushAsync()
+        expect(performCount() == 1, "replacement settings handle the next sequence")
+
+        let mouseFake = FakeQuickTriggerEnvironment()
+        let mouseContext = ContextProbe()
+        let (_, mousePerformCount, _) = makeCoordinator(
+            fake: mouseFake,
+            contextProbe: mouseContext
+        )
+        mouseFake.settings.keyboardMode = .singleTap
+        expect(!mouseFake.fireMouse(.leftDown), "settings-changing ordinary mouse input is not consumed")
+        expect(
+            mouseFake.mouseRemoveCount == 0,
+            "mouse callback does not mutate the shared listener registry while it is dispatching"
+        )
+        mouseFake.flushAsync()
+        expect(mouseFake.mouseRemoveCount == 1, "deferred refresh removes the old mouse listener")
+        expect(mouseFake.mouseInstallCount == 2, "deferred refresh installs one replacement listener")
+        expect(mousePerformCount() == 0, "settings refresh does not perform an Action")
+    }
+
+    private static func sideButtonPairsOnceAndRejectsStaleUp() {
+        let fake = FakeQuickTriggerEnvironment()
+        let context = ContextProbe()
+        let (coordinator, performCount, visuals) = makeCoordinator(fake: fake, contextProbe: context)
+        expect(fake.fireMouse(.otherDown, button: 3), "configured side-button down is consumed")
+        fake.flushAsync()
+        expect(performCount() == 0, "side button does not perform on down")
+        expect(fake.fireMouse(.otherUp, button: 3), "matching side-button up is consumed")
+        fake.flushAsync()
+        expect(performCount() == 1, "matching side-button pair performs exactly once")
+        expect(visuals() == [.pressed, .idle], "side-button visual changes are deduplicated")
+
+        expect(fake.fireMouse(.otherDown, button: 3), "second side-button down locks context")
+        fake.flushAsync()
+        context.validIDs.insert(2)
+        coordinator.start(context: context.context(2))
+        expect(!fake.fireMouse(.otherUp, button: 3), "old context mouseUp is not routed")
+        fake.flushAsync()
+        expect(performCount() == 1, "old context mouseUp cannot perform")
+
+        expect(fake.fireMouse(.otherDown, button: 3), "new context accepts a fresh side-button down")
+        fake.flushAsync()
+        let stoppedMouseHandler = fake.activeMouseHandler
+        coordinator.stop()
+        expect(
+            stoppedMouseHandler?(QuickTriggerMouseEvent(kind: .otherUp, button: 3)) == false,
+            "stopped mouse listener callback is permanently stale"
+        )
+        fake.flushAsync()
+        expect(performCount() == 1, "mouseUp delivered after stop cannot perform")
+    }
+
+    private static func disabledInputsDoNotTrigger() {
+        let fake = FakeQuickTriggerEnvironment()
+        fake.settings.keyboardModifier = .disabled
+        fake.settings.mouseButton = nil
+        let context = ContextProbe()
+        let (_, performCount, visuals) = makeCoordinator(fake: fake, contextProbe: context)
+
+        expect(fake.globalInstallCount == 0, "disabled keyboard installs no global modifier monitor")
+        expect(fake.localModifierInstallCount == 0, "disabled keyboard installs no local modifier monitor")
+        expect(!fake.fireMouse(.otherDown, button: 3), "unconfigured side button is not consumed")
+        expect(!fake.fireMouse(.otherUp, button: 3), "unconfigured side-button up is not consumed")
+        fake.flushAsync()
+        expect(performCount() == 0, "disabled keyboard and unconfigured mouse never perform")
+        expect(visuals().isEmpty, "disabled inputs publish no visual updates")
+    }
+
+    private static func ineligibleContextDoesNotInstallUntilEligible() {
+        let fake = FakeQuickTriggerEnvironment()
+        let context = ContextProbe()
+        context.validIDs.insert(1)
+        context.canPerform = false
+        fake.modifierFlags = .control
+        let coordinator = QuickTriggerCoordinator(environment: fake.makeEnvironment())
+        var visuals: [QuickTriggerVisualState] = []
+        var performCount = 0
+        coordinator.onPerformPrimary = { performCount += 1 }
+        coordinator.onVisualStateChanged = { visuals.append($0) }
+        coordinator.start(context: context.context(1))
+        expect(fake.globalInstallCount == 0, "no Action installs no modifier monitor")
+        expect(fake.mouseInstallCount == 0, "no Action installs no mouse listener")
+        expect(visuals.isEmpty, "ineligible idle context publishes nothing")
+
+        context.canPerform = true
+        coordinator.start(context: context.context(1))
+        expect(fake.globalInstallCount == 1, "same context installs once when Action becomes available")
+        expect(fake.mouseInstallCount == 1, "eligible context installs shared mouse listener")
+        fake.fireModifier(keyCode: 59, flags: [], timestamp: 0.1)
+        fake.flushAsync()
+        expect(performCount == 0, "newly eligible context suppresses a pre-held modifier release")
+    }
+}

--- a/Copied-mac/Tests/ToastCommandTests.swift
+++ b/Copied-mac/Tests/ToastCommandTests.swift
@@ -136,9 +136,49 @@ struct ToastCommandTests {
 
     private static func productionWiringUsesOneCommandPath() {
         let controller = try! String(contentsOfFile: "ToastWindowController.swift", encoding: .utf8)
+        let quickTrigger = try! String(
+            contentsOfFile: "QuickTriggerCoordinator.swift",
+            encoding: .utf8
+        )
         let view = try! String(contentsOfFile: "ToastView.swift", encoding: .utf8)
         expect(controller.contains("private func handleCommand("), "controller has one command receiver")
         expect(controller.contains("onCommand:"), "controller injects the command receiver")
+        expect(controller.contains("QuickTriggerCoordinator"), "controller delegates quick trigger ownership")
+        expect(
+            controller.contains("handleCommand(.performPrimary)"),
+            "coordinator intent enters the unified primary command path"
+        )
+        expect(controller.contains("quickTriggerCoordinator.suspend()"), "expand suspends quick trigger")
+        expect(
+            controller.contains("quickTriggerCoordinator.resume(context:"),
+            "collapse completion resumes quick trigger"
+        )
+        expect(controller.contains("quickTriggerCoordinator.stop()"), "dismiss stops quick trigger")
+        for forbiddenDetail in [
+            "globalTriggerModifierMonitor",
+            "localTriggerModifierMonitor",
+            "localOtherEventMonitor",
+            "mouseEventListenerToken",
+            "keyboardQuickTrigger",
+            "modifierKeyPolicy",
+            "mouseQuickTrigger",
+            "quickTriggerTimeout",
+            "quickTriggerHIDPoll",
+            "captureQuickTriggerEventCounters",
+        ] {
+            expect(
+                !controller.contains(forbiddenDetail),
+                "controller no longer owns \(forbiddenDetail)"
+            )
+        }
+        expect(
+            !controller.contains("GlobalMouseEventCoordinator.shared.addListener"),
+            "controller does not register the shared mouse listener"
+        )
+        expect(
+            !quickTrigger.contains("addLocalMonitorForEvents(matching: .leftMouse"),
+            "quick trigger never adds a local left-mouse monitor"
+        )
         expect(!controller.contains("addLocalMonitorForEvents(matching: .leftMouseUp)"), "window mouseUp routing is removed")
         expect(!controller.contains("ManualPrimaryActionEventGuard"), "manual primary guard is removed")
         expect(!controller.contains("CollapsedToastMouseUpPolicy"), "collapsed mouseUp policy is removed")

--- a/Copied-mac/ToastWindowController.swift
+++ b/Copied-mac/ToastWindowController.swift
@@ -17,16 +17,16 @@ final class ToastWindowController {
 
     private var isDismissing = false
     private var dismissGeneration = 0
-    private var globalTriggerModifierMonitor: Any?
-    private var localTriggerModifierMonitor: Any?
-    private var localOtherEventMonitor: Any?
-    private var mouseEventListenerToken: UUID?
-    private var keyboardQuickTrigger = KeyboardQuickTriggerStateMachine(mode: .doubleTap)
-    private var modifierKeyPolicy = QuickTriggerModifierKeyPolicy(targetModifier: .control)
-    private var mouseQuickTrigger = MouseQuickTriggerStateMachine()
-    private var quickTriggerContextGeneration = 0
-    private var quickTriggerTimeout: DispatchWorkItem?
-    private var quickTriggerHIDPoll: DispatchWorkItem?
+    private lazy var quickTriggerCoordinator: QuickTriggerCoordinator = {
+        let coordinator = QuickTriggerCoordinator()
+        coordinator.onPerformPrimary = { [weak self] in
+            self?.handleCommand(.performPrimary)
+        }
+        coordinator.onVisualStateChanged = { [weak self] state in
+            self?.viewModel.quickTriggerVisualState = state
+        }
+        return coordinator
+    }()
     private let displayDuration: TimeInterval = 3.0
 
     private var isExpandingOrCollapsing = false
@@ -42,7 +42,6 @@ final class ToastWindowController {
         isDismissing = false
         isExpandingOrCollapsing = false
         dismissGeneration += 1
-        quickTriggerContextGeneration += 1
         contentView?.layer?.filters = nil
         // Always recreate window for fresh Space association.
         // Fullscreen Spaces can lose track of reused windows after
@@ -96,270 +95,40 @@ final class ToastWindowController {
 
         if isMouseInsideWindow() {} else { startDismissTimer() }
 
-        installQuickTriggerMonitors()
+        quickTriggerCoordinator.start(context: makeQuickTriggerContext())
     }
 
     // MARK: - Quick trigger
-
-    private func installQuickTriggerMonitors() {
-        let settings = QuickTriggerSettings.current()
-        guard quickTriggerAction() != nil else { return }
-        keyboardQuickTrigger = KeyboardQuickTriggerStateMachine(mode: settings.keyboardMode)
-        modifierKeyPolicy = QuickTriggerModifierKeyPolicy(targetModifier: settings.keyboardModifier)
-
-        if settings.keyboardModifier != .disabled {
-            let triggerFlags = settings.keyboardModifier.nseventFlags
-            let targetIsDown = NSEvent.modifierFlags.contains(triggerFlags)
-            modifierKeyPolicy.appeared(preExisting: targetIsDown)
-            keyboardQuickTrigger.appeared(preExisting: targetIsDown)
-
-            globalTriggerModifierMonitor = NSEvent.addGlobalMonitorForEvents(matching: .flagsChanged) {
-                [weak self] event in self?.handleModifierFlagsChanged(event)
-            }
-            localTriggerModifierMonitor = NSEvent.addLocalMonitorForEvents(matching: .flagsChanged) {
-                [weak self] event in
-                self?.handleModifierFlagsChanged(event)
-                return event
-            }
-        }
-
-        localOtherEventMonitor = NSEvent.addLocalMonitorForEvents(
-            matching: .keyDown
-        ) { [weak self] event in
-            self?.cancelKeyboardQuickTrigger(
-                reason: "localOtherEvent type=\(event.type.rawValue) keyCode=\(event.keyCode)"
-            )
-            self?.cancelMouseQuickTrigger(reason: "localOtherEvent type=\(event.type.rawValue)")
-            return event
-        }
-
-        mouseEventListenerToken = GlobalMouseEventCoordinator.shared.addListener(
-            promptForAccessibility: false
-        ) { [weak self] type, event in
-            self?.handleGlobalMouseEvent(type: type, event: event) ?? false
-        }
-    }
-
-    private func handleModifierFlagsChanged(_ event: NSEvent) {
-        let settings = QuickTriggerSettings.current()
-        let countersAtEntry = captureQuickTriggerEventCounters()
-        guard let window else {
-            cancelKeyboardQuickTrigger(reason: "flagsChanged window=nil")
-            return
-        }
-        guard window.isVisible else {
-            cancelKeyboardQuickTrigger(reason: "flagsChanged windowNotVisible")
-            return
-        }
-        guard !isDismissing else {
-            cancelKeyboardQuickTrigger(reason: "flagsChanged isDismissing=true")
-            return
-        }
-        guard quickTriggerAction() != nil else {
-            cancelKeyboardQuickTrigger(reason: "flagsChanged action=nil")
-            return
-        }
-        guard settings.keyboardModifier != .disabled else {
-            cancelKeyboardQuickTrigger(reason: "flagsChanged modifier=disabled")
-            return
-        }
-        guard modifierKeyPolicy.targetModifier == settings.keyboardModifier else {
-            cancelKeyboardQuickTrigger(reason: "flagsChanged configuredModifierChanged")
-            return
-        }
-
-        let decision = modifierKeyPolicy.handleFlagsChanged(
-            keyCode: event.keyCode,
-            eventFlags: event.modifierFlags,
-            sequenceActive: keyboardQuickTrigger.visualState != .idle
-        )
-
-        let isDown: Bool
-        switch decision {
-        case .ignore:
-            return
-        case let .cancelOtherModifier(keyCode):
-            cancelKeyboardQuickTrigger(reason: "realOtherModifier keyCode=\(keyCode)")
-            cancelMouseQuickTrigger(reason: "realOtherModifier keyCode=\(keyCode)")
-            return
-        case .cancelTargetSideConflict:
-            cancelKeyboardQuickTrigger(reason: "targetLeftRightConflict keyCode=\(event.keyCode)")
-            cancelMouseQuickTrigger(reason: "targetLeftRightConflict")
-            return
-        case .targetDown:
-            isDown = true
-        case .targetUp:
-            isDown = false
-        }
-        cancelMouseQuickTrigger(reason: "keyboardModifierTransition isDown=\(isDown)")
-
-        if isDown {
-            let shouldTrigger = keyboardQuickTrigger.targetChanged(
-                isDown: true,
-                at: event.timestamp,
-                counters: countersAtEntry,
-                context: quickTriggerContextGeneration
-            )
-            updateQuickTriggerVisualState()
-            if shouldTrigger { performQuickTriggerAction() }
-        } else {
-            let capturedContext = quickTriggerContextGeneration
-            let timestamp = event.timestamp
-            DispatchQueue.main.async { [weak self] in
-                guard let self else { return }
-                guard !self.isDismissing else {
-                    self.cancelKeyboardQuickTrigger(reason: "flagsUpAsync isDismissing=true")
-                    return
-                }
-                guard capturedContext == self.quickTriggerContextGeneration else {
-                    self.cancelKeyboardQuickTrigger(
-                        reason: "flagsUpAsync contextChanged captured=\(capturedContext) current=\(self.quickTriggerContextGeneration)"
-                    )
-                    return
-                }
-                let counters = self.captureQuickTriggerEventCounters()
-                let shouldTrigger = self.keyboardQuickTrigger.targetChanged(
-                    isDown: false,
-                    at: timestamp,
-                    counters: counters,
-                    context: capturedContext
-                )
-                self.updateQuickTriggerVisualState()
-                if shouldTrigger { self.performQuickTriggerAction() }
-            }
-        }
-    }
-
-    private func handleGlobalMouseEvent(type: CGEventType, event: CGEvent) -> Bool {
-        let button = Int(event.getIntegerValueField(.mouseEventButtonNumber))
-        cancelKeyboardQuickTrigger(
-            reason: "globalMouse type=\(type.rawValue) button=\(button)"
-        )
-        let settings = QuickTriggerSettings.current()
-        guard let configuredButton = settings.mouseButton else {
-            cancelMouseQuickTrigger(reason: "globalMouse noConfiguredButton type=\(type.rawValue)")
-            return false
-        }
-        switch type {
-        case .otherMouseDown where button == configuredButton:
-            let consume = mouseQuickTrigger.mouseDown(
-                button: button,
-                configuredButton: configuredButton,
-                context: quickTriggerContextGeneration,
-                canPerform: window?.isVisible == true && !isDismissing && quickTriggerAction() != nil
-            )
-            if consume {
-                DispatchQueue.main.async { [weak self] in
-                    self?.viewModel.quickTriggerVisualState = .pressed
-                }
-            }
-            return consume
-        case .otherMouseUp where button == configuredButton:
-            let result = mouseQuickTrigger.mouseUp(
-                button: button,
-                context: quickTriggerContextGeneration
-            )
-            if result.consume {
-                DispatchQueue.main.async { [weak self] in
-                    guard let self else { return }
-                    self.viewModel.quickTriggerVisualState = .idle
-                    if result.trigger { self.performQuickTriggerAction() }
-                }
-            }
-            return result.consume
-        default:
-            cancelMouseQuickTrigger(reason: "globalMouse unmatched type=\(type.rawValue) button=\(button)")
-            return false
-        }
-    }
-
-    private func captureQuickTriggerEventCounters() -> QuickTriggerEventCounters {
-        func count(_ type: CGEventType) -> UInt32 {
-            CGEventSource.counterForEventType(.hidSystemState, eventType: type)
-        }
-        return QuickTriggerEventCounters(
-            keyDown: count(.keyDown),
-            leftMouseDown: count(.leftMouseDown),
-            leftMouseUp: count(.leftMouseUp),
-            rightMouseDown: count(.rightMouseDown),
-            rightMouseUp: count(.rightMouseUp),
-            otherMouseDown: count(.otherMouseDown),
-            otherMouseUp: count(.otherMouseUp),
-            scrollWheel: count(.scrollWheel)
-        )
-    }
-
-    private func updateQuickTriggerVisualState() {
-        quickTriggerTimeout?.cancel()
-        viewModel.quickTriggerVisualState = keyboardQuickTrigger.visualState
-        scheduleQuickTriggerHIDValidation()
-        guard keyboardQuickTrigger.visualState == .waitingForSecondTap else { return }
-        let work = DispatchWorkItem { [weak self] in
-            guard let self else { return }
-            self.keyboardQuickTrigger.tick(at: ProcessInfo.processInfo.systemUptime)
-            self.viewModel.quickTriggerVisualState = self.keyboardQuickTrigger.visualState
-        }
-        quickTriggerTimeout = work
-        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(351), execute: work)
-    }
-
-    private func scheduleQuickTriggerHIDValidation() {
-        quickTriggerHIDPoll?.cancel()
-        quickTriggerHIDPoll = nil
-        guard keyboardQuickTrigger.visualState != .idle else { return }
-        let capturedContext = quickTriggerContextGeneration
-        let work = DispatchWorkItem { [weak self] in
-            guard let self,
-                  capturedContext == self.quickTriggerContextGeneration else { return }
-            let isValid = self.keyboardQuickTrigger.validate(
-                counters: self.captureQuickTriggerEventCounters(),
-                context: capturedContext
-            )
-            self.viewModel.quickTriggerVisualState = self.keyboardQuickTrigger.visualState
-            if isValid { self.scheduleQuickTriggerHIDValidation() }
-        }
-        quickTriggerHIDPoll = work
-        DispatchQueue.main.asyncAfter(deadline: .now() + .milliseconds(20), execute: work)
-    }
-
-    private func cancelKeyboardQuickTrigger(reason _: String) {
-        let needsVisualReset = viewModel.quickTriggerVisualState.shouldPublishIdleReset
-        quickTriggerTimeout?.cancel()
-        quickTriggerTimeout = nil
-        quickTriggerHIDPoll?.cancel()
-        quickTriggerHIDPoll = nil
-        keyboardQuickTrigger.cancel()
-        if needsVisualReset {
-            viewModel.quickTriggerVisualState = .idle
-        }
-    }
-
-    private func invalidateQuickTriggerContext(reason _: String) {
-        let needsVisualReset = viewModel.quickTriggerVisualState.shouldPublishIdleReset
-        quickTriggerContextGeneration += 1
-        keyboardQuickTrigger.contextChanged()
-        cancelMouseQuickTrigger(reason: "contextInvalidated")
-        quickTriggerTimeout?.cancel()
-        quickTriggerTimeout = nil
-        quickTriggerHIDPoll?.cancel()
-        quickTriggerHIDPoll = nil
-        if needsVisualReset {
-            viewModel.quickTriggerVisualState = .idle
-        }
-    }
 
     private func quickTriggerAction() -> (any ClipboardAction)? {
         viewModel.resultOverlay.map { CopyTextAction(text: $0.copyText) }
             ?? viewModel.primaryAction
     }
 
-    private func performQuickTriggerAction() {
-        guard quickTriggerAction() != nil, !isDismissing else { return }
-        handleCommand(.performPrimary)
+    private func makeQuickTriggerContext() -> QuickTriggerCoordinator.Context {
+        let generation = dismissGeneration
+        return QuickTriggerCoordinator.Context(
+            id: generation,
+            isValid: { [weak self] in
+                self?.dismissGeneration == generation
+            },
+            canPerform: { [weak self] in
+                guard let self else { return false }
+                return self.window?.isVisible == true
+                    && !self.isDismissing
+                    && !self.isExpandingOrCollapsing
+                    && !self.viewModel.isExpanded
+                    && self.quickTriggerAction() != nil
+            }
+        )
     }
 
-    private func cancelMouseQuickTrigger(reason _: String) {
-        mouseQuickTrigger.cancelPendingTrigger()
+    private func refreshQuickTriggerContextIfEligible() {
+        guard window?.isVisible == true,
+              !isDismissing,
+              !isExpandingOrCollapsing,
+              !viewModel.isExpanded else { return }
+        quickTriggerCoordinator.start(context: makeQuickTriggerContext())
     }
 
     // MARK: - Action execution
@@ -447,7 +216,7 @@ final class ToastWindowController {
     private func handleExpand() {
         guard !viewModel.isExpanded, !isExpandingOrCollapsing else { return }
         isExpandingOrCollapsing = true
-        removeQuickTriggerMonitors()
+        quickTriggerCoordinator.suspend()
         cancelDismiss()
         pauseDismissTimer()
 
@@ -486,7 +255,9 @@ final class ToastWindowController {
                 self?.removeWindowBlur()
                 self?.isExpandingOrCollapsing = false
                 if self?.isMouseInsideWindow() == false { self?.startDismissTimer() }
-                self?.installQuickTriggerMonitors()
+                if let self {
+                    self.quickTriggerCoordinator.resume(context: self.makeQuickTriggerContext())
+                }
             }
         }
     }
@@ -569,11 +340,11 @@ final class ToastWindowController {
     private func cancelDismiss() {
         isDismissing = false
         dismissGeneration += 1
-        invalidateQuickTriggerContext(reason: "cancelDismiss dismissGeneration=\(dismissGeneration)")
         contentView?.layer?.filters = nil
         contentView?.layer?.removeAnimation(forKey: "dismissBlurAnim")
         window?.alphaValue = 1.0
         window?.orderFront(nil)
+        refreshQuickTriggerContextIfEligible()
     }
 
     /// 异步 inline action 的统一入口。处理 dismiss 竞态 + 非动画窗口 resize。
@@ -825,7 +596,6 @@ final class ToastWindowController {
         setExpandedTextSurfaceVisible(false)
         dismissTimer?.invalidate()
         dismissTimer = nil
-        invalidateQuickTriggerContext(reason: "dismissToast animated=\(animated)")
         removeAllMonitors()
         if animated {
             let gen = dismissGeneration
@@ -871,22 +641,6 @@ final class ToastWindowController {
     }
 
     private func removeAllMonitors() {
-        removeQuickTriggerMonitors()
-    }
-
-    private func removeQuickTriggerMonitors() {
-        if let m = globalTriggerModifierMonitor { NSEvent.removeMonitor(m); globalTriggerModifierMonitor = nil }
-        if let m = localTriggerModifierMonitor  { NSEvent.removeMonitor(m); localTriggerModifierMonitor = nil }
-        if let m = localOtherEventMonitor { NSEvent.removeMonitor(m); localOtherEventMonitor = nil }
-        GlobalMouseEventCoordinator.shared.removeListener(mouseEventListenerToken)
-        mouseEventListenerToken = nil
-        quickTriggerTimeout?.cancel()
-        quickTriggerTimeout = nil
-        quickTriggerHIDPoll?.cancel()
-        quickTriggerHIDPoll = nil
-        keyboardQuickTrigger.cancel()
-        modifierKeyPolicy.reset()
-        mouseQuickTrigger.reset()
-        viewModel.quickTriggerVisualState = .idle
+        quickTriggerCoordinator.stop()
     }
 }

--- a/Copied-mac/build.sh
+++ b/Copied-mac/build.sh
@@ -25,6 +25,7 @@ SOURCES=(
     KeyboardShortcutSettings.swift
     QuickTriggerModifierKeyPolicy.swift
     QuickTriggerStateMachine.swift
+    QuickTriggerCoordinator.swift
     AppUpdateModels.swift
     AppUpdateService.swift
     PluginActionTemplate.swift

--- a/Copied-mac/run-tests.sh
+++ b/Copied-mac/run-tests.sh
@@ -18,6 +18,18 @@ swiftc -parse-as-library \
 "$TEST_BUILD_DIR/QuickTriggerStateMachineTests"
 
 swiftc -parse-as-library \
+    KeyboardShortcutSettings.swift \
+    QuickTriggerModifierKeyPolicy.swift \
+    QuickTriggerStateMachine.swift \
+    GlobalMouseEventCoordinator.swift \
+    QuickTriggerCoordinator.swift \
+    Tests/QuickTriggerCoordinatorTests.swift \
+    -framework AppKit \
+    -framework CoreGraphics \
+    -o "$TEST_BUILD_DIR/QuickTriggerCoordinatorTests"
+"$TEST_BUILD_DIR/QuickTriggerCoordinatorTests"
+
+swiftc -parse-as-library \
     AppUpdateModels.swift \
     Tests/AppUpdateModelsTests.swift \
     -o "$TEST_BUILD_DIR/AppUpdateModelsTests"


### PR DESCRIPTION
## 变更

- 新增 `QuickTriggerCoordinator`，集中拥有键盘修饰键、侧键、HID 计数、350ms 状态机、timeout/poll 与监听器生命周期
- `ToastWindowController` 只保留 toast 生命周期、动画与 `ToastCommand.performPrimary` 路由，不再保存快速触发 token、状态机或定时任务
- 保持真实 keyCode 策略与共享 `GlobalMouseEventCoordinator`，未新增 Event Tap 或本地左右键 monitor
- 视觉状态按值去重，旧 context、旧 release/timeout/poll/mouseUp 均不能操作新 toast
- 设置变化时延后替换监听，避免在共享鼠标 listener 分发期间修改注册表；资源释放和 `start` / `suspend` / `resume` / `stop` 均为幂等
- 新增可注入 fake 环境的 Coordinator 回归测试，并加强 controller 单命令路径接线检查

## 迁移与实机验收

- 迁移前基线：默认双击、取消输入、展开/收起、单击模式、其他修饰键、侧键与周期一点击回归均正常
- 迁移后日志：10 次 Coordinator 主 Action 意图对应 10 次接受的 `performPrimary` 命令和 10 次快速触发 Action；另 1 次 Action 来自手动按钮
- 侧键完成 2 次 down/up 单次触发；58 次 controller 视觉回调全部为真实值变化，idle → idle 为 0
- 展开开始即移除监听，展开态无监听，收起完成只恢复一套；未发现重复或陈旧 context 触发
- 最终无诊断代码候选已由用户完成实机验收，其他行为未发现异常

### Mac Mouse Fix A/B 诊断

- 用户发现按住 Command 时滚轮、松开后再按一次可能触发；文件探针显示该滚轮未到达共享 CGEventTap、NSEvent monitor、HID counter 或 Quartz event-age 层
- 系统进程确认 Mac Mouse Fix Helper 正在运行；关闭其中对应的小映射设置后，同一操作恢复 `scrollWheel`，协调器立即从 pressed 取消到 idle，后续不触发
- 根因确认为重映射工具在 Copied 之前吞掉输入，不属于迁移回归；未增加重复监听、raw IOHID 或额外权限路径
- 全部临时 logger、Quartz 探针和无效监听实验均已删除

## 自动验证

- `./run-tests.sh`: PASS
  - AppFilter 29/29
  - DateTime 31/31
  - Math 50/50
  - QuickTriggerStateMachineTests
  - QuickTriggerCoordinatorTests
  - AppUpdateModelsTests
  - AppUpdateServiceTests
  - InteractionWiringTests
  - ToastCommandTests
- 强制删除 `.build/.source_fingerprint` 后 `./build.sh`: PASS，无警告
- `git diff --check`: PASS；候选源码无未提交改动
- `VERSION` / `Info.plist`: 无变更

## 文档同步

- README 增加 `QuickTriggerCoordinator` 架构入口，并说明鼠标重映射工具对侧键和“修饰键 + 滚轮”的上游拦截限制
- CLAUDE/AGENTS 明确 Coordinator 所有权、幂等生命周期、context/monitor epoch 与禁止旁路监听规则
- 规则手册从约 18KB 精简到 15KB 以内，移除与 README/DESIGN 重复的实现叙述

## 当前状态

- 功能与文档均已通过用户验收，Ready，等待明确合并授权
- 本周期是无行为变化的 `refactor:`，不升级版本，不创建 Release
